### PR TITLE
Sorry i have implemented to much here.

### DIFF
--- a/libraries/cms/helper/usergroups.php
+++ b/libraries/cms/helper/usergroups.php
@@ -66,8 +66,6 @@ final class JHelperUsergroups
 	 * @param   array    $groups  Array of groups
 	 * @param   integer  $mode    Working mode for this class
 	 *
-	 * @return  void
-	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
 	public function __construct(array $groups = array(), $mode = self::MODE_INSTANCE)


### PR DESCRIPTION
https://travis-ci.org/joomla/joomla-cms/jobs/156466958

```
FILE: ...home/travis/build/joomla/joomla-cms/libraries/cms/helper/usergroups.php
--------------------------------------------------------------------------------
FOUND 1 ERROR(S) AFFECTING 1 LINE(S)
--------------------------------------------------------------------------------
 69 | ERROR | Constructor and destructor comments must not have a @return tag
--------------------------------------------------------------------------------
UPGRADE TO PHP_CODESNIFFER 2.0 TO FIX ERRORS AUTOMATICALLY
--------------------------------------------------------------------------------
```
